### PR TITLE
Add --diff-content option for git-like verbose diff output

### DIFF
--- a/exe/dotsync
+++ b/exe/dotsync
@@ -51,6 +51,7 @@ opt_parser = OptionParser.new do |opts|
       --only-config         Show only the config section
       --only-mappings       Show only the mappings section
       -v, --verbose         Force showing all available information
+      --diff-content        Show git-like content diff for modified files
       --trace               Show full error backtraces (for debugging)
       --version             Show version number
       -h, --help            Show this help message
@@ -110,6 +111,10 @@ opt_parser = OptionParser.new do |opts|
 
   opts.on("-v", "--verbose", "Force showing all available information") do
     options[:verbose] = true
+  end
+
+  opts.on("--diff-content", "Show git-like content diff for modified files") do
+    options[:diff_content] = true
   end
 
   opts.on("--trace", "Show full error backtraces (for debugging)") do

--- a/lib/dotsync/actions/concerns/mappings_transfer.rb
+++ b/lib/dotsync/actions/concerns/mappings_transfer.rb
@@ -62,7 +62,7 @@ module Dotsync
       logger.log("")
     end
 
-    def show_differences
+    def show_differences(diff_content: false)
       info("Differences:", icon: :diff)
       differs.flat_map(&:additions).sort.each do |path|
         logger.log("#{Icons.diff_created}#{path}", color: Colors.diff_additions)
@@ -75,6 +75,15 @@ module Dotsync
       end
       logger.log("  No differences") unless has_differences?
       logger.log("")
+
+      show_content_diffs if diff_content && has_modifications?
+    end
+
+    def show_content_diffs
+      info("Content Differences:", icon: :diff)
+      modification_pairs.each do |pair|
+        Dotsync::ContentDiff.new(pair[:src], pair[:dest], logger).display
+      end
     end
 
     def transfer_mappings
@@ -106,6 +115,14 @@ module Dotsync
 
       def has_differences?
         differs.any? { |differ| differ.any? }
+      end
+
+      def has_modifications?
+        differs.any? { |differ| differ.modifications.any? }
+      end
+
+      def modification_pairs
+        differs.flat_map(&:modification_pairs)
       end
 
       def confirm_action

--- a/lib/dotsync/actions/concerns/output_sections.rb
+++ b/lib/dotsync/actions/concerns/output_sections.rb
@@ -12,7 +12,8 @@ module Dotsync
         mappings_legend: !(quiet || options[:no_legend] || options[:no_mappings] || options[:only_diff]),
         mappings: !(quiet || options[:no_mappings] || options[:only_diff]),
         differences_legend: !(quiet || options[:no_legend] || options[:no_diff_legend] || options[:no_diff] || options[:only_config] || options[:only_mappings]),
-        differences: !(quiet || options[:no_diff] || options[:only_mappings] || options[:only_config])
+        differences: !(quiet || options[:no_diff] || options[:only_mappings] || options[:only_config]),
+        diff_content: options[:diff_content] || false
       }
 
       if verbose

--- a/lib/dotsync/actions/pull_action.rb
+++ b/lib/dotsync/actions/pull_action.rb
@@ -15,7 +15,7 @@ module Dotsync
       show_mappings_legend if output_sections[:mappings_legend]
       show_mappings if output_sections[:mappings]
       show_differences_legend if has_differences? && output_sections[:differences_legend]
-      show_differences if output_sections[:differences]
+      show_differences(diff_content: output_sections[:diff_content]) if output_sections[:differences]
 
       return unless options[:apply]
 

--- a/lib/dotsync/actions/push_action.rb
+++ b/lib/dotsync/actions/push_action.rb
@@ -13,7 +13,7 @@ module Dotsync
       show_mappings_legend if output_sections[:mappings_legend]
       show_mappings if output_sections[:mappings]
       show_differences_legend if has_differences? && output_sections[:differences_legend]
-      show_differences if output_sections[:differences]
+      show_differences(diff_content: output_sections[:diff_content]) if output_sections[:differences]
 
       return unless options[:apply]
 

--- a/lib/dotsync/loaders/pull_loader.rb
+++ b/lib/dotsync/loaders/pull_loader.rb
@@ -11,6 +11,7 @@ require "terminal-table"
 require_relative "../utils/file_transfer"
 require_relative "../utils/directory_differ"
 require_relative "../utils/config_cache"
+require_relative "../utils/content_diff"
 
 # Models
 require_relative "../models/mapping"

--- a/lib/dotsync/loaders/push_loader.rb
+++ b/lib/dotsync/loaders/push_loader.rb
@@ -11,6 +11,7 @@ require "terminal-table"
 require_relative "../utils/file_transfer"
 require_relative "../utils/directory_differ"
 require_relative "../utils/config_cache"
+require_relative "../utils/content_diff"
 
 # Models
 require_relative "../models/mapping"

--- a/lib/dotsync/models/diff.rb
+++ b/lib/dotsync/models/diff.rb
@@ -3,12 +3,13 @@
 module Dotsync
   # Represents the differences between two directories
   class Diff
-    attr_reader :additions, :modifications, :removals
+    attr_reader :additions, :modifications, :removals, :modification_pairs
 
-    def initialize(additions: [], modifications: [], removals: [])
+    def initialize(additions: [], modifications: [], removals: [], modification_pairs: [])
       @additions = additions
       @modifications = modifications
       @removals = removals
+      @modification_pairs = modification_pairs
     end
 
     def any?

--- a/lib/dotsync/utils/content_diff.rb
+++ b/lib/dotsync/utils/content_diff.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Dotsync
+  class ContentDiff
+    COLORS = {
+      header: 103,       # Purple for file headers
+      hunk: 36,          # Cyan for @@ lines
+      addition: 34,      # Blue for added lines (consistent with diff_additions)
+      deletion: 88,      # Red for removed lines (consistent with diff_removals)
+      context: 240       # Gray for context lines
+    }.freeze
+
+    def initialize(src_path, dest_path, logger)
+      @src_path = src_path
+      @dest_path = dest_path
+      @logger = logger
+    end
+
+    def display
+      return unless displayable?
+
+      diff_output = generate_diff
+      return if diff_output.empty?
+
+      display_header
+      colorize_and_display(diff_output)
+    end
+
+    private
+      def displayable?
+        text_file?(@src_path) && text_file?(@dest_path)
+      end
+
+      def text_file?(path)
+        return false unless File.file?(path)
+
+        # Check if file appears to be text by reading first few bytes
+        begin
+          sample = File.read(path, 8192) || ""
+          # Binary files typically contain null bytes
+          !sample.include?("\x00")
+        rescue StandardError
+          false
+        end
+      end
+
+      def generate_diff
+        # Use system diff with unified format
+        # diff returns exit code 1 when files differ, so we can't use backticks directly
+        output = `diff -u "#{@dest_path}" "#{@src_path}" 2>/dev/null`
+        output.lines.drop(2).join # Drop the first two header lines, we'll add our own
+      rescue StandardError
+        ""
+      end
+
+      def display_header
+        @logger.log("--- #{@dest_path}", color: COLORS[:header])
+        @logger.log("+++ #{@src_path}", color: COLORS[:header])
+      end
+
+      def colorize_and_display(diff_output)
+        diff_output.each_line do |line|
+          color = line_color(line)
+          @logger.log(line.chomp, color: color)
+        end
+        @logger.log("")
+      end
+
+      def line_color(line)
+        case line[0]
+        when "+"
+          COLORS[:addition]
+        when "-"
+          COLORS[:deletion]
+        when "@"
+          COLORS[:hunk]
+        else
+          COLORS[:context]
+        end
+      end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `--diff-content` CLI option to show git-like unified diff for modified files
- Create `ContentDiff` utility with color-coded output (blue additions, red deletions, cyan hunks)
- Update `Diff` model to store source/destination path pairs for modifications
- Skip binary files automatically

## Test plan

- [x] Run `bundle exec rspec` - all 411 tests pass
- [x] Run `./exe/dotsync --help` - shows new option
- [ ] Test with actual dotfiles: `./exe/dotsync push --diff-content`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)