### PR TITLE
Fix hook runner not expanding env vars in file paths

### DIFF
--- a/lib/dotsync/utils/hook_runner.rb
+++ b/lib/dotsync/utils/hook_runner.rb
@@ -5,6 +5,8 @@ require "shellwords"
 
 module Dotsync
   class HookRunner
+    include Dotsync::PathUtils
+
     def initialize(mapping:, changed_files:, logger:)
       @mapping = mapping
       @changed_files = changed_files
@@ -24,7 +26,7 @@ module Dotsync
 
     private
       def expand_template(command)
-        files_str = @changed_files.map { |f| Shellwords.escape(f) }.join(" ")
+        files_str = @changed_files.map { |f| Shellwords.escape(sanitize_path(f)) }.join(" ")
 
         command
           .gsub("{files}", files_str)

--- a/spec/dotsync/utils/hook_runner_spec.rb
+++ b/spec/dotsync/utils/hook_runner_spec.rb
@@ -126,6 +126,26 @@ RSpec.describe Dotsync::HookRunner do
       end
     end
 
+    context "with files containing environment variables" do
+      let(:mapping) do
+        Dotsync::Mapping.new(
+          "src" => src,
+          "dest" => dest,
+          "hooks" => ["echo {files}"]
+        )
+      end
+      let(:changed_files) { ["$HOME/Scripts/setup.sh"] }
+      let(:runner) { described_class.new(mapping: mapping, changed_files: changed_files, logger: logger) }
+
+      it "expands environment variables in file paths" do
+        results = runner.execute
+
+        expect(results.first[:stdout]).to include(ENV["HOME"])
+        expect(results.first[:stdout]).to include("Scripts/setup.sh")
+        expect(results.first[:success]).to be true
+      end
+    end
+
     context "with template variables {src} and {dest}" do
       let(:mapping) do
         Dotsync::Mapping.new(


### PR DESCRIPTION
## Summary
- Include `PathUtils` in `HookRunner` and call `sanitize_path` on `{files}` paths before shell-escaping
- Add spec for env var expansion in hook file paths

Closes #23

## Test plan
- [x] All 491 examples pass (new spec added)
- [x] 96.47% line coverage, 82.89% branch coverage
- [x] Verified `codesign -s - {files}` now receives expanded paths like `/Users/dsaenz/Scripts/setup.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)