### PR TITLE
Add --force-hooks flag to re-run hooks when no files changed

### DIFF
--- a/exe/dotsync
+++ b/exe/dotsync
@@ -52,6 +52,7 @@ opt_parser = OptionParser.new do |opts|
       --only-mappings       Show only the mappings section
       -v, --verbose         Force showing all available information
       --diff-content        Show git-like content diff for modified files
+      --force-hooks         Run hooks even when no files changed
       --trace               Show full error backtraces (for debugging)
       --version             Show version number
       -h, --help            Show this help message
@@ -115,6 +116,10 @@ opt_parser = OptionParser.new do |opts|
 
   opts.on("--diff-content", "Show git-like content diff for modified files") do
     options[:diff_content] = true
+  end
+
+  opts.on("--force-hooks", "Run hooks even when no files changed") do
+    options[:force_hooks] = true
   end
 
   opts.on("--trace", "Show full error backtraces (for debugging)") do

--- a/lib/dotsync/actions/base_action.rb
+++ b/lib/dotsync/actions/base_action.rb
@@ -23,6 +23,7 @@ module Dotsync
       def show_options(options)
         info("Options:", icon: :options)
         logger.log("  Apply: #{options[:apply] ? "TRUE" : "FALSE"}")
+        logger.log("  Force hooks: TRUE") if options[:force_hooks]
         logger.log("")
       end
   end

--- a/lib/dotsync/actions/pull_action.rb
+++ b/lib/dotsync/actions/pull_action.rb
@@ -16,7 +16,7 @@ module Dotsync
       show_mappings if output_sections[:mappings]
       show_differences_legend if has_differences? && output_sections[:differences_legend]
       show_differences(diff_content: output_sections[:diff_content]) if output_sections[:differences]
-      show_hooks_preview if output_sections[:differences]
+      show_hooks_preview(force: options[:force_hooks]) if output_sections[:differences]
 
       return unless options[:apply]
 
@@ -33,7 +33,7 @@ module Dotsync
       end
 
       transfer_mappings
-      execute_hooks
+      execute_hooks(force: options[:force_hooks])
       action("Mappings pulled", icon: :done)
     end
 

--- a/lib/dotsync/actions/push_action.rb
+++ b/lib/dotsync/actions/push_action.rb
@@ -14,7 +14,7 @@ module Dotsync
       show_mappings if output_sections[:mappings]
       show_differences_legend if has_differences? && output_sections[:differences_legend]
       show_differences(diff_content: output_sections[:diff_content]) if output_sections[:differences]
-      show_hooks_preview if output_sections[:differences]
+      show_hooks_preview(force: options[:force_hooks]) if output_sections[:differences]
 
       return unless options[:apply]
 
@@ -24,7 +24,7 @@ module Dotsync
       end
 
       transfer_mappings
-      execute_hooks
+      execute_hooks(force: options[:force_hooks])
       action("Mappings pushed", icon: :done)
     end
   end

--- a/spec/dotsync/actions/pull_action_spec.rb
+++ b/spec/dotsync/actions/pull_action_spec.rb
@@ -220,6 +220,20 @@ RSpec.describe Dotsync::PullAction do
 
             action.execute(apply: true, yes: true)
           end
+
+          context "with force_hooks option" do
+            it "executes hooks on all dest files" do
+              expect_any_instance_of(Dotsync::HookRunner).to receive(:execute).and_return([])
+
+              action.execute(apply: true, yes: true, force_hooks: true)
+            end
+
+            it "shows hooks preview in dry-run mode" do
+              expect_any_instance_of(Dotsync::HookRunner).to receive(:preview).and_return(["echo hook_ran"])
+
+              action.execute(force_hooks: true)
+            end
+          end
         end
       end
 

--- a/spec/dotsync/actions/push_action_spec.rb
+++ b/spec/dotsync/actions/push_action_spec.rb
@@ -227,6 +227,20 @@ RSpec.describe Dotsync::PushAction do
 
             action.execute(apply: true, yes: true)
           end
+
+          context "with force_hooks option" do
+            it "executes hooks on all dest files" do
+              expect_any_instance_of(Dotsync::HookRunner).to receive(:execute).and_return([])
+
+              action.execute(apply: true, yes: true, force_hooks: true)
+            end
+
+            it "shows hooks preview in dry-run mode" do
+              expect_any_instance_of(Dotsync::HookRunner).to receive(:preview).and_return(["echo hook_ran"])
+
+              action.execute(force_hooks: true)
+            end
+          end
         end
       end
 

--- a/spec/dotsync/actions/support/logger_helper.rb
+++ b/spec/dotsync/actions/support/logger_helper.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 module LoggerHelper
-  def expect_show_options(apply: false)
+  def expect_show_options(apply: false, force_hooks: false)
     value = apply ? "TRUE" : "FALSE"
     expect(logger).to receive(:info).with("Options:", icon: :options).ordered
     expect(logger).to receive(:log).with("  Apply: #{value}").ordered
+    expect(logger).to receive(:log).with("  Force hooks: TRUE").ordered if force_hooks
     expect(logger).to receive(:log).with("").ordered
   end
 


### PR DESCRIPTION
## Summary

- Add `--force-hooks` CLI flag that allows re-running post-sync hooks even when no files changed
- When force is active and no diffs exist, hooks run against all destination files instead of being skipped
- Useful when a hook (e.g., `codesign`) fails after files are already synced — previously required manually editing files to create a fake diff

Closes #25

## Test plan

- [x] `bundle exec rspec` — 495 examples, 0 failures
- [x] `bundle exec rubocop` — 73 files, no offenses
- [ ] Manual: `dotsync pull --force-hooks` shows hooks in preview
- [ ] Manual: `dotsync pull --force-hooks -ay` executes hooks on all dest files

🤖 Generated with [Claude Code](https://claude.com/claude-code)