### PR TITLE
Decouple Terminal::Table from domain logic via TableRenderer

### DIFF
--- a/lib/dotsync.rb
+++ b/lib/dotsync.rb
@@ -11,7 +11,7 @@ require "logger"
 require "forwardable" # Ruby standard library
 require "ostruct"
 require "find"
-require "terminal-table"
+require_relative "dotsync/utils/table_renderer"
 
 # Base classes
 require_relative "dotsync/errors"

--- a/lib/dotsync/actions/concerns/mappings_transfer.rb
+++ b/lib/dotsync/actions/concerns/mappings_transfer.rb
@@ -48,15 +48,13 @@ module Dotsync
       info("Environment variables:", icon: :env_vars)
 
       rows = env_vars.map { |env_var| [env_var, ENV[env_var]] }.sort_by(&:first)
-      table = Terminal::Table.new(rows: rows)
-      logger.log(table)
+      logger.log(Dotsync::TableRenderer.new(rows: rows).render)
       logger.log("")
     end
 
     def show_mappings_legend
       info("Mappings Legend:", icon: :legend)
-      table = Terminal::Table.new(rows: MAPPINGS_LEGEND)
-      logger.log(table)
+      logger.log(Dotsync::TableRenderer.new(rows: MAPPINGS_LEGEND).render)
       logger.log("")
     end
 
@@ -70,15 +68,13 @@ module Dotsync
           colorize_env_vars(mapping.original_dest)
         ]
       end
-      table = Terminal::Table.new(headings: ["Flags", "Source", "Destination"], rows: rows)
-      logger.log(table)
+      logger.log(Dotsync::TableRenderer.new(headings: ["Flags", "Source", "Destination"], rows: rows).render)
       logger.log("")
     end
 
     def show_differences_legend
       info("Differences Legend:", icon: :legend)
-      table = Terminal::Table.new(rows: DIFFERENCES_LEGEND)
-      logger.log(table)
+      logger.log(Dotsync::TableRenderer.new(rows: DIFFERENCES_LEGEND).render)
       logger.log("")
     end
 

--- a/lib/dotsync/loaders/pull_loader.rb
+++ b/lib/dotsync/loaders/pull_loader.rb
@@ -5,7 +5,7 @@ require_relative "../core"
 
 # Gems needed for pull
 require "toml-rb"
-require "terminal-table"
+require_relative "../utils/table_renderer"
 
 # Utils needed for pull
 require_relative "../utils/file_transfer"

--- a/lib/dotsync/loaders/push_loader.rb
+++ b/lib/dotsync/loaders/push_loader.rb
@@ -5,7 +5,7 @@ require_relative "../core"
 
 # Gems needed for push
 require "toml-rb"
-require "terminal-table"
+require_relative "../utils/table_renderer"
 
 # Utils needed for push
 require_relative "../utils/file_transfer"

--- a/lib/dotsync/utils/table_renderer.rb
+++ b/lib/dotsync/utils/table_renderer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "terminal-table"
+
+module Dotsync
+  class TableRenderer
+    attr_reader :rows
+
+    def initialize(rows:, headings: nil)
+      @rows = rows
+      @headings = headings
+    end
+
+    def render
+      options = { rows: @rows }
+      options[:headings] = @headings if @headings
+      Terminal::Table.new(**options).to_s
+    end
+  end
+end

--- a/spec/dotsync/actions/support/logger_helper.rb
+++ b/spec/dotsync/actions/support/logger_helper.rb
@@ -42,10 +42,13 @@ module LoggerHelper
 
   private
     def expect_logger_log_table(expected_rows)
-      expect(logger).to receive(:log) do |table|
-        expect(table).to be_a(Terminal::Table)
-        rows_cells = table.rows.map { |row| row.cells.map(&:value) }
-        expect(rows_cells).to eq(expected_rows)
+      expect(logger).to receive(:log) do |rendered|
+        expect(rendered).to be_a(String)
+        expected_rows.each do |row|
+          row.each do |cell|
+            expect(rendered).to include(cell.to_s)
+          end
+        end
       end.ordered
     end
 end

--- a/spec/dotsync/utils/table_renderer_spec.rb
+++ b/spec/dotsync/utils/table_renderer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Dotsync::TableRenderer do
+  describe "#render" do
+    it "renders rows as a formatted string" do
+      renderer = described_class.new(rows: [["a", "b"], ["c", "d"]])
+      result = renderer.render
+
+      expect(result).to be_a(String)
+      expect(result).to include("a")
+      expect(result).to include("b")
+      expect(result).to include("c")
+      expect(result).to include("d")
+    end
+
+    it "includes headings when provided" do
+      renderer = described_class.new(headings: ["Name", "Value"], rows: [["foo", "bar"]])
+      result = renderer.render
+
+      expect(result).to include("Name")
+      expect(result).to include("Value")
+      expect(result).to include("foo")
+      expect(result).to include("bar")
+    end
+
+    it "exposes rows for inspection" do
+      rows = [["x", "y"]]
+      renderer = described_class.new(rows: rows)
+
+      expect(renderer.rows).to eq(rows)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Extract `TableRenderer` class wrapping `Terminal::Table` behind a `rows + headings → string` interface
- Update `MappingsTransfer` to pass plain data through the renderer instead of constructing `Terminal::Table` objects directly
- Decouple test assertions from `Terminal::Table` internals (`.rows`, `.cells`, `.value`) — now asserts on rendered string content
- Move `require "terminal-table"` into `TableRenderer`, removing it from loaders and top-level require

Closes #27

## Test plan

- [x] Full RSpec suite passes (498 examples, 0 failures)
- [x] RuboCop passes (74 files, no offenses)
- [x] Coverage thresholds met (96.12% line, 82.22% branch)
- [x] New `TableRenderer` spec covers rows, headings, and `#rows` accessor

🤖 Generated with [Claude Code](https://claude.com/claude-code)