### PR TITLE
Add manifest-based orphan cleanup for non-force sync mappings

### DIFF
--- a/lib/dotsync.rb
+++ b/lib/dotsync.rb
@@ -34,6 +34,7 @@ require_relative "dotsync/utils/config_cache"
 require_relative "dotsync/utils/config_merger"
 require_relative "dotsync/utils/parallel"
 require_relative "dotsync/utils/hook_runner"
+require_relative "dotsync/utils/manifest"
 
 # Models
 require_relative "dotsync/models/mapping"

--- a/lib/dotsync/actions/concerns/mappings_transfer.rb
+++ b/lib/dotsync/actions/concerns/mappings_transfer.rb
@@ -93,6 +93,8 @@ module Dotsync
       logger.log("")
 
       show_content_diffs if diff_content && has_modifications?
+
+      show_orphan_preview if respond_to?(:manifests_xdg_data_home, true)
     end
 
     def show_content_diffs
@@ -131,6 +133,28 @@ module Dotsync
       errors.each do |error_msg, info_msg|
         logger.error(error_msg)
         logger.info(info_msg) if info_msg
+      end
+    end
+
+    def cleanup_orphans
+      valid_mappings.each do |mapping|
+        next unless mapping.has_inclusions? && !mapping.force? && mapping.manifest_key
+
+        current_files = dest_files_matching_inclusions(mapping)
+        manifest = Dotsync::Manifest.new(
+          dest_dir: mapping.dest,
+          key: mapping.manifest_key,
+          xdg_data_home: manifests_xdg_data_home
+        )
+
+        manifest.orphans(current_files).each do |orphan_path|
+          next unless File.exist?(orphan_path)
+
+          FileUtils.rm(orphan_path)
+          logger.log("#{Icons.diff_removed}#{orphan_path}", color: Colors.diff_removals)
+        end
+
+        manifest.write(current_files)
       end
     end
 
@@ -224,6 +248,43 @@ module Dotsync
 
       def valid_mappings
         mappings.select(&:valid?)
+      end
+
+      def show_orphan_preview
+        orphans = []
+        valid_mappings.each do |mapping|
+          next unless mapping.has_inclusions? && !mapping.force? && mapping.manifest_key
+
+          current_files = dest_files_matching_inclusions(mapping)
+          manifest = Dotsync::Manifest.new(
+            dest_dir: mapping.dest,
+            key: mapping.manifest_key,
+            xdg_data_home: manifests_xdg_data_home
+          )
+          orphans.concat(manifest.orphans(current_files).select { |p| File.exist?(p) })
+        end
+
+        return if orphans.empty?
+
+        info("Orphans to remove:", icon: :diff)
+        orphans.sort.each do |path|
+          logger.log("#{Icons.diff_removed}#{path}", color: Colors.diff_removals)
+        end
+        logger.log("")
+      end
+
+      def dest_files_matching_inclusions(mapping)
+        return [] unless File.directory?(mapping.dest)
+
+        files = []
+        Find.find(mapping.dest) do |path|
+          next if path == mapping.dest
+          next if File.directory?(path)
+          next unless mapping.include?(path)
+
+          files << Pathname.new(path).relative_path_from(Pathname.new(mapping.dest)).to_s
+        end
+        files
       end
 
       def all_dest_files(mapping)

--- a/lib/dotsync/actions/pull_action.rb
+++ b/lib/dotsync/actions/pull_action.rb
@@ -6,6 +6,7 @@ module Dotsync
     include OutputSections
 
     def_delegator :@config, :backups_root
+    def_delegator :@config, :manifests_xdg_data_home
 
     def execute(options = {})
       output_sections = compute_output_sections(options)
@@ -33,6 +34,7 @@ module Dotsync
       end
 
       transfer_mappings
+      cleanup_orphans
       execute_hooks(force: options[:force_hooks])
       action("Mappings pulled", icon: :done)
     end

--- a/lib/dotsync/config/concerns/sync_mappings.rb
+++ b/lib/dotsync/config/concerns/sync_mappings.rb
@@ -147,6 +147,7 @@ module Dotsync
         base["force"] = mapping["force"] if mapping.key?("force")
         base["ignore"] = mapping["ignore"] if mapping.key?("ignore")
         base["only"] = only if only
+        base["sync_type"] = shorthand_type
 
         # Resolve hooks for direction
         if mapping.key?("hooks")

--- a/lib/dotsync/config/pull_action_config.rb
+++ b/lib/dotsync/config/pull_action_config.rb
@@ -13,6 +13,10 @@ module Dotsync
       File.join(xdg_data_home, "dotsync", "backups")
     end
 
+    def manifests_xdg_data_home
+      xdg_data_home
+    end
+
     private
       SECTION_NAME = "pull"
 

--- a/lib/dotsync/loaders/pull_loader.rb
+++ b/lib/dotsync/loaders/pull_loader.rb
@@ -14,6 +14,7 @@ require_relative "../utils/config_cache"
 require_relative "../utils/content_diff"
 require_relative "../utils/parallel"
 require_relative "../utils/hook_runner"
+require_relative "../utils/manifest"
 
 # Models
 require_relative "../models/mapping"

--- a/lib/dotsync/models/mapping.rb
+++ b/lib/dotsync/models/mapping.rb
@@ -21,7 +21,7 @@ module Dotsync
   class Mapping
     include Dotsync::PathUtils
 
-    attr_reader :original_src, :original_dest, :original_ignores, :original_only
+    attr_reader :original_src, :original_dest, :original_ignores, :original_only, :sync_type
 
     def initialize(attributes)
       @original_src = attributes["src"]
@@ -30,6 +30,7 @@ module Dotsync
       @original_only = Array(attributes["only"])
       @force = attributes["force"] || false
       @hooks = Array(attributes["hooks"])
+      @sync_type = attributes["sync_type"]
 
       @sanitized_src, @sanitized_dest, @sanitized_ignores, @sanitized_only = process_paths(
         @original_src,
@@ -63,6 +64,27 @@ module Dotsync
 
     def has_hooks?
       @hooks.any?
+    end
+
+    def has_inclusions?
+      @original_only.any?
+    end
+
+    def manifest_key
+      return nil unless @sync_type
+
+      shorthand_base = SyncMappings::SHORTHANDS.dig(@sync_type, :local)
+      return @sync_type unless shorthand_base
+
+      expanded_base = sanitize_path(shorthand_base)
+      if dest == expanded_base
+        @sync_type
+      elsif dest.start_with?("#{expanded_base}/")
+        subpath = dest.delete_prefix("#{expanded_base}/")
+        "#{@sync_type}--#{subpath}"
+      else
+        @sync_type
+      end
     end
 
     def directories?
@@ -209,10 +231,6 @@ module Dotsync
 
       def has_ignores?
         @original_ignores.any?
-      end
-
-      def has_inclusions?
-        @original_only.any?
       end
 
       def process_paths(raw_src, raw_dest, raw_ignores, raw_only)

--- a/lib/dotsync/utils/manifest.rb
+++ b/lib/dotsync/utils/manifest.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Dotsync
+  class Manifest
+    MANIFESTS_DIR = "dotsync/manifests"
+
+    # @param dest_dir [String] the mapping's destination directory (absolute)
+    # @param key [String] manifest filename key (e.g., "xdg_bin")
+    # @param xdg_data_home [String] base path for manifest storage
+    def initialize(dest_dir:, key:, xdg_data_home:)
+      @dest_dir = dest_dir
+      @key = key
+      @manifest_path = File.join(xdg_data_home, MANIFESTS_DIR, "#{key}.json")
+    end
+
+    # Returns array of relative file paths from stored manifest
+    # @return [Array<String>]
+    def read
+      return [] unless File.exist?(@manifest_path)
+
+      data = JSON.parse(File.read(@manifest_path))
+      Array(data["files"])
+    rescue JSON::ParserError
+      []
+    end
+
+    # Writes current file list to manifest
+    # @param files [Array<String>] relative file paths
+    def write(files)
+      FileUtils.mkdir_p(File.dirname(@manifest_path))
+      File.write(@manifest_path, JSON.pretty_generate({ "files" => files.sort }))
+    end
+
+    # Returns orphan absolute paths: files in old manifest but not in current_files
+    # @param current_files [Array<String>] relative file paths currently synced
+    # @return [Array<String>] absolute paths ready for deletion
+    def orphans(current_files)
+      previous = read
+      orphaned = previous - current_files
+      orphaned.map { |file| File.join(@dest_dir, file) }
+    end
+  end
+end

--- a/spec/dotsync/actions/pull_action_spec.rb
+++ b/spec/dotsync/actions/pull_action_spec.rb
@@ -30,11 +30,13 @@ RSpec.describe Dotsync::PullAction do
   end
   let(:mappings) { [mapping1, mapping2] }
   let(:backups_root) { File.join(root, "backups") }
+  let(:manifests_xdg_data_home) { File.join(root, "data") }
   let(:config) do
     instance_double(
       "Dotsync::PullActionConfig",
       mappings: mappings,
-      backups_root: backups_root
+      backups_root: backups_root,
+      manifests_xdg_data_home: manifests_xdg_data_home
     )
   end
   let(:logger) { instance_double("Dotsync::Logger") }
@@ -323,6 +325,100 @@ RSpec.describe Dotsync::PullAction do
                 expect(logger).to have_received(:log).with("  #{backup_path}")
               end
             end
+          end
+        end
+      end
+
+      context "orphan cleanup" do
+        let(:bin_src) { File.join(root, "bin_src") }
+        let(:bin_dest) { File.join(root, "bin_dest") }
+        let(:mapping_with_inclusions) do
+          Dotsync::Mapping.new(
+            "src" => bin_src,
+            "dest" => bin_dest,
+            "only" => ["grafanactl", "elasticctl"],
+            "sync_type" => "xdg_bin"
+          )
+        end
+        let(:mappings) { [mapping_with_inclusions] }
+        let(:manifest_path) { File.join(manifests_xdg_data_home, "dotsync/manifests/xdg_bin.json") }
+
+        before do
+          ENV["XDG_BIN_HOME"] = bin_dest
+          ENV["XDG_BIN_HOME_MIRROR"] = bin_src
+          FileUtils.mkdir_p(bin_src)
+          FileUtils.mkdir_p(bin_dest)
+          # Create files in both src and dest
+          File.write(File.join(bin_src, "grafanactl"), "new content")
+          File.write(File.join(bin_src, "elasticctl"), "new content")
+          File.write(File.join(bin_dest, "grafanactl"), "old content")
+          File.write(File.join(bin_dest, "elasticctl"), "old content")
+          # Create orphan in dest (was in old manifest, no longer in src)
+          File.write(File.join(bin_dest, "setup-grafana"), "orphan content")
+
+          # Write old manifest with the orphan file
+          FileUtils.mkdir_p(File.dirname(manifest_path))
+          File.write(manifest_path, '{"files": ["elasticctl", "grafanactl", "setup-grafana"]}')
+
+          allow(Dotsync::FileTransfer).to receive(:new).with(mapping_with_inclusions).and_return(
+            instance_double("Dotsync::FileTransfer", transfer: nil)
+          )
+        end
+
+        after do
+          ENV.delete("XDG_BIN_HOME")
+          ENV.delete("XDG_BIN_HOME_MIRROR")
+        end
+
+        it "removes orphan files after transfer" do
+          action.execute(apply: true, yes: true)
+
+          expect(File.exist?(File.join(bin_dest, "setup-grafana"))).to be false
+        end
+
+        it "updates the manifest after cleanup" do
+          action.execute(apply: true, yes: true)
+
+          data = JSON.parse(File.read(manifest_path))
+          expect(data["files"]).to contain_exactly("elasticctl", "grafanactl")
+        end
+
+        it "preserves non-orphan files" do
+          action.execute(apply: true, yes: true)
+
+          expect(File.exist?(File.join(bin_dest, "grafanactl"))).to be true
+          expect(File.exist?(File.join(bin_dest, "elasticctl"))).to be true
+        end
+
+        context "when no previous manifest exists" do
+          before do
+            FileUtils.rm(manifest_path)
+          end
+
+          it "writes a new manifest without removing any files" do
+            action.execute(apply: true, yes: true)
+
+            expect(File.exist?(File.join(bin_dest, "setup-grafana"))).to be true
+            data = JSON.parse(File.read(manifest_path))
+            expect(data["files"]).to contain_exactly("elasticctl", "grafanactl")
+          end
+        end
+
+        context "with force mapping" do
+          let(:mapping_with_inclusions) do
+            Dotsync::Mapping.new(
+              "src" => bin_src,
+              "dest" => bin_dest,
+              "only" => ["grafanactl", "elasticctl"],
+              "force" => true,
+              "sync_type" => "xdg_bin"
+            )
+          end
+
+          it "skips orphan cleanup for force mappings" do
+            action.execute(apply: true, yes: true)
+
+            expect(File.exist?(File.join(bin_dest, "setup-grafana"))).to be true
           end
         end
       end

--- a/spec/dotsync/config/concerns/sync_mappings_spec.rb
+++ b/spec/dotsync/config/concerns/sync_mappings_spec.rb
@@ -374,6 +374,51 @@ RSpec.describe Dotsync::SyncMappings do
       ENV.delete("HOME_MIRROR")
     end
 
+    describe "sync_type preservation" do
+      let(:config) do
+        {
+          "sync" => {
+            "xdg_config" => [
+              { "path" => "nvim", "force" => true }
+            ]
+          }
+        }
+      end
+
+      it "preserves sync_type on shorthand mappings for pull" do
+        instance = test_class.new(config)
+        mappings = instance.sync_mappings_for_pull
+
+        expect(mappings.first.sync_type).to eq("xdg_config")
+      end
+
+      it "preserves sync_type on shorthand mappings for push" do
+        instance = test_class.new(config)
+        mappings = instance.sync_mappings_for_push
+
+        expect(mappings.first.sync_type).to eq("xdg_config")
+      end
+
+      context "with explicit mappings" do
+        let(:config) do
+          {
+            "sync" => {
+              "mappings" => [
+                { "local" => local_path, "remote" => remote_path }
+              ]
+            }
+          }
+        end
+
+        it "does not set sync_type on explicit mappings" do
+          instance = test_class.new(config)
+          mappings = instance.sync_mappings_for_pull
+
+          expect(mappings.first.sync_type).to be_nil
+        end
+      end
+    end
+
     describe "#sync_mappings_for_push with xdg_config shorthand" do
       let(:config) do
         {

--- a/spec/dotsync/models/mapping_spec.rb
+++ b/spec/dotsync/models/mapping_spec.rb
@@ -57,6 +57,104 @@ RSpec.describe Dotsync::Mapping do
     end
   end
 
+  describe "#sync_type" do
+    context "without sync_type attribute" do
+      it "returns nil" do
+        expect(mapping_entry.sync_type).to be_nil
+      end
+    end
+
+    context "with sync_type attribute" do
+      let(:attributes) do
+        {
+          "src" => src,
+          "dest" => dest,
+          "sync_type" => "xdg_bin"
+        }
+      end
+
+      it "returns the sync_type" do
+        expect(mapping_entry.sync_type).to eq("xdg_bin")
+      end
+    end
+  end
+
+  describe "#manifest_key" do
+    context "without sync_type" do
+      it "returns nil" do
+        expect(mapping_entry.manifest_key).to be_nil
+      end
+    end
+
+    context "with sync_type and no subpath" do
+      before do
+        ENV["XDG_BIN_HOME"] = File.join(root, "bin")
+        ENV["XDG_BIN_HOME_MIRROR"] = File.join(root, "bin_mirror")
+        FileUtils.mkdir_p(ENV["XDG_BIN_HOME"])
+        FileUtils.mkdir_p(ENV["XDG_BIN_HOME_MIRROR"])
+      end
+
+      after do
+        ENV.delete("XDG_BIN_HOME")
+        ENV.delete("XDG_BIN_HOME_MIRROR")
+      end
+
+      let(:attributes) do
+        {
+          "src" => "$XDG_BIN_HOME_MIRROR",
+          "dest" => "$XDG_BIN_HOME",
+          "sync_type" => "xdg_bin"
+        }
+      end
+
+      it "returns the sync_type as key" do
+        expect(mapping_entry.manifest_key).to eq("xdg_bin")
+      end
+    end
+
+    context "with sync_type and subpath" do
+      before do
+        ENV["XDG_CONFIG_HOME"] = File.join(root, "config")
+        ENV["XDG_CONFIG_HOME_MIRROR"] = File.join(root, "config_mirror")
+        FileUtils.mkdir_p(File.join(ENV["XDG_CONFIG_HOME"], "nvim"))
+        FileUtils.mkdir_p(File.join(ENV["XDG_CONFIG_HOME_MIRROR"], "nvim"))
+      end
+
+      after do
+        ENV.delete("XDG_CONFIG_HOME")
+        ENV.delete("XDG_CONFIG_HOME_MIRROR")
+      end
+
+      let(:attributes) do
+        {
+          "src" => "$XDG_CONFIG_HOME_MIRROR/nvim",
+          "dest" => "$XDG_CONFIG_HOME/nvim",
+          "sync_type" => "xdg_config"
+        }
+      end
+
+      it "returns sync_type with subpath" do
+        expect(mapping_entry.manifest_key).to eq("xdg_config--nvim")
+      end
+    end
+  end
+
+  describe "#has_inclusions?" do
+    context "without only attribute" do
+      it "returns false" do
+        expect(mapping_entry.has_inclusions?).to be false
+      end
+    end
+
+    context "with only attribute" do
+      let(:only) { ["file_a", "file_b"] }
+
+      it "returns true" do
+        expect(mapping_entry.has_inclusions?).to be true
+      end
+    end
+  end
+
   describe "#ignores" do
     context "without ignore attribute" do
       let(:attributes) { { "src" => src, "dest" => dest } }

--- a/spec/dotsync/utils/manifest_spec.rb
+++ b/spec/dotsync/utils/manifest_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Dotsync::Manifest do
+  let(:root) { File.join("/tmp", "dotsync_manifest_test") }
+  let(:dest_dir) { File.join(root, "dest") }
+  let(:xdg_data_home) { File.join(root, "data") }
+  let(:key) { "xdg_bin" }
+  let(:manifest_path) { File.join(xdg_data_home, "dotsync/manifests/#{key}.json") }
+
+  subject(:manifest) do
+    described_class.new(dest_dir: dest_dir, key: key, xdg_data_home: xdg_data_home)
+  end
+
+  before do
+    FileUtils.mkdir_p(dest_dir)
+    FileUtils.mkdir_p(xdg_data_home)
+  end
+
+  after do
+    FileUtils.rm_rf(root)
+  end
+
+  describe "#read" do
+    context "when no manifest exists" do
+      it "returns an empty array" do
+        expect(manifest.read).to eq([])
+      end
+    end
+
+    context "when manifest exists with files" do
+      before do
+        FileUtils.mkdir_p(File.dirname(manifest_path))
+        File.write(manifest_path, '{"files": ["grafanactl", "elasticctl"]}')
+      end
+
+      it "returns the file list" do
+        expect(manifest.read).to eq(["grafanactl", "elasticctl"])
+      end
+    end
+
+    context "when manifest contains invalid JSON" do
+      before do
+        FileUtils.mkdir_p(File.dirname(manifest_path))
+        File.write(manifest_path, "not json")
+      end
+
+      it "returns an empty array" do
+        expect(manifest.read).to eq([])
+      end
+    end
+  end
+
+  describe "#write" do
+    it "creates the manifest directory and writes the file list" do
+      manifest.write(["grafanactl", "elasticctl"])
+
+      expect(File.exist?(manifest_path)).to be true
+      data = JSON.parse(File.read(manifest_path))
+      expect(data["files"]).to eq(["elasticctl", "grafanactl"])
+    end
+
+    it "overwrites an existing manifest" do
+      manifest.write(["old_file"])
+      manifest.write(["new_file"])
+
+      data = JSON.parse(File.read(manifest_path))
+      expect(data["files"]).to eq(["new_file"])
+    end
+  end
+
+  describe "#orphans" do
+    before do
+      FileUtils.mkdir_p(File.dirname(manifest_path))
+      File.write(manifest_path, '{"files": ["setup-grafana", "grafanactl", "elasticctl"]}')
+    end
+
+    it "returns absolute paths of files in old manifest but not in current_files" do
+      current_files = ["grafanactl", "elasticctl"]
+      result = manifest.orphans(current_files)
+
+      expect(result).to eq([File.join(dest_dir, "setup-grafana")])
+    end
+
+    it "returns empty array when no orphans exist" do
+      current_files = ["setup-grafana", "grafanactl", "elasticctl"]
+      result = manifest.orphans(current_files)
+
+      expect(result).to eq([])
+    end
+
+    it "returns all previous files as orphans when current_files is empty" do
+      result = manifest.orphans([])
+
+      expect(result).to contain_exactly(
+        File.join(dest_dir, "setup-grafana"),
+        File.join(dest_dir, "grafanactl"),
+        File.join(dest_dir, "elasticctl")
+      )
+    end
+
+    context "when no previous manifest exists" do
+      before do
+        FileUtils.rm(manifest_path)
+      end
+
+      it "returns empty array" do
+        result = manifest.orphans(["grafanactl"])
+        expect(result).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add manifest tracking so dotsync detects and removes orphaned files (e.g., renamed scripts) on subsequent pulls
- Only applies to non-force mappings with `only` filters — force-mode already handles cleanup
- Manifests stored at `$XDG_DATA_HOME/dotsync/manifests/<key>.json`

## Changes

- **Mapping model**: `sync_type` attribute, `manifest_key` method, public `has_inclusions?`
- **SyncMappings**: Pass `sync_type` through shorthand conversion
- **New `Dotsync::Manifest`**: Read/write/orphan detection utility
- **MappingsTransfer**: `cleanup_orphans` method + dry-run orphan preview
- **PullAction**: Call `cleanup_orphans` after `transfer_mappings`
- **PullActionConfig**: Expose `xdg_data_home` for manifest storage

Closes #31

## Test plan

- [x] `bundle exec rspec` — 536 examples, 0 failures
- [x] Rubocop passes (pre-commit hook)
- [x] Coverage: 96.44% line / 82.74% branch (above thresholds)
- [ ] Manual: create xdg_bin mapping with `only`, pull, rename file, pull again — verify orphan removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)