### PR TITLE
Fix backup crash on macOS when directories contain socket files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.4.1] - 2026-03-17
+
+### Fixed
+
+- Fix backup crash on macOS when directories contain socket files (#33)
+  - Replace `FileUtils.cp_r` with custom `cp_r_regular_files` that skips sockets, FIFOs, and device files
+  - Socket paths exceeding macOS 104-byte limit no longer cause backup failures
+  - Symlinks are properly preserved during backup
+
 ## [0.4.0] - 2026-03-01
 
 ### Added
@@ -473,6 +482,7 @@ Add gem executables
 
 Initial version
 
+[0.4.1]: https://github.com/dsaenztagarro/dotsync/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/dsaenztagarro/dotsync/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/dsaenztagarro/dotsync/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/dsaenztagarro/dotsync/compare/v0.3.1...v0.3.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dotsync (0.4.0)
+    dotsync (0.4.1)
       fileutils (~> 1.7.3)
       find (~> 0.2.0)
       listen (~> 3.9.0)

--- a/lib/dotsync/actions/pull_action.rb
+++ b/lib/dotsync/actions/pull_action.rb
@@ -62,10 +62,27 @@ module Dotsync
           if File.file?(mapping.src)
             FileUtils.cp(mapping.dest, backup_path)
           else
-            FileUtils.cp_r(mapping.dest, backup_path)
+            cp_r_regular_files(mapping.dest, backup_path)
           end
         end
         true
+      end
+
+      # Recursively copy a directory, skipping sockets, FIFOs, and device files.
+      # FileUtils.cp_r fails on macOS when socket paths exceed the 104-byte limit.
+      def cp_r_regular_files(src, dest)
+        FileUtils.mkdir_p(dest)
+        Dir.each_child(src) do |entry|
+          src_entry = File.join(src, entry)
+          dest_entry = File.join(dest, entry)
+          if File.symlink?(src_entry)
+            FileUtils.ln_s(File.readlink(src_entry), dest_entry)
+          elsif File.directory?(src_entry)
+            cp_r_regular_files(src_entry, dest_entry)
+          elsif File.file?(src_entry)
+            FileUtils.cp(src_entry, dest_entry, preserve: true)
+          end
+        end
       end
 
       def purge_old_backups

--- a/lib/dotsync/version.rb
+++ b/lib/dotsync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dotsync
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/dotsync/actions/pull_action_spec.rb
+++ b/spec/dotsync/actions/pull_action_spec.rb
@@ -307,6 +307,29 @@ RSpec.describe Dotsync::PullAction do
             expect(logger).to have_received(:log).with("  #{backup_dir}")
           end
 
+          context "when directory contains socket files" do
+            let(:socket_path) { File.join(mapping1.dest, "daemon.sock") }
+
+            before do
+              require "socket"
+              UNIXServer.new(socket_path)
+            end
+
+            after do
+              File.delete(socket_path) if File.exist?(socket_path)
+            end
+
+            it "skips socket files during backup" do
+              subject
+
+              timestamp = Time.now.strftime("%Y%m%d%H%M%S")
+              backup_dir = File.join(backups_root, timestamp)
+              expect(Dir.exist?(backup_dir)).to eq(true)
+              expect(File.exist?(File.join(backup_dir, "folder_dest", "daemon.sock"))).to eq(false)
+              expect(File.read(File.join(backup_dir, "folder_dest", "file1"))).to eq("#{file1_dest} content")
+            end
+          end
+
           context "when there are more than 10 backups" do
             before do
               1.upto(12) do |day|


### PR DESCRIPTION
## Summary

- Fix `ds pull --apply` crashing when backed-up directories contain Unix socket files on macOS
- Socket paths exceeding the 104-byte `sun_path` limit caused `FileUtils.cp_r` to fail
- Bump version to 0.4.1

Closes #33

## Changes

### Code
- **`lib/dotsync/actions/pull_action.rb`**: Replace `FileUtils.cp_r` with `cp_r_regular_files` — a recursive copy that skips sockets, FIFOs, and device files while preserving symlinks and file metadata

### Tests
- **`spec/dotsync/actions/pull_action_spec.rb`**: Add spec that creates a real Unix socket in the dest directory and verifies it is skipped during backup

### Release
- **`lib/dotsync/version.rb`**: 0.4.0 → 0.4.1
- **`CHANGELOG.md`**: Add 0.4.1 entry
- **`Gemfile.lock`**: Version bump

## Test plan
- [ ] `bundle exec rspec` — full suite passes
- [ ] `bundle exec rubocop` — no offenses
- [ ] New socket-skipping spec verifies the fix directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)