### PR TITLE
Fix backup crash on pre-existing symlinks (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.4.2] - 2026-03-22
+
+### Fixed
+
+- Fix `cp_r_regular_files` crash on pre-existing symlinks during backup (#35)
+  - Add `FileUtils.rm_f` before `FileUtils.ln_s` to handle leftover symlinks from partial backup runs
+
 ## [0.4.1] - 2026-03-17
 
 ### Fixed

--- a/lib/dotsync/actions/pull_action.rb
+++ b/lib/dotsync/actions/pull_action.rb
@@ -76,6 +76,7 @@ module Dotsync
           src_entry = File.join(src, entry)
           dest_entry = File.join(dest, entry)
           if File.symlink?(src_entry)
+            FileUtils.rm_f(dest_entry)
             FileUtils.ln_s(File.readlink(src_entry), dest_entry)
           elsif File.directory?(src_entry)
             cp_r_regular_files(src_entry, dest_entry)

--- a/lib/dotsync/version.rb
+++ b/lib/dotsync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dotsync
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/spec/dotsync/actions/pull_action_spec.rb
+++ b/spec/dotsync/actions/pull_action_spec.rb
@@ -330,6 +330,28 @@ RSpec.describe Dotsync::PullAction do
             end
           end
 
+          context "when backup directory has pre-existing symlinks" do
+            it "overwrites the existing symlinks without crashing" do
+              timestamp = Time.now.strftime("%Y%m%d%H%M%S")
+              backup_dir = File.join(backups_root, timestamp)
+
+              # Simulate a partial backup from a previous failed run
+              FileUtils.mkdir_p(File.join(backup_dir, "folder_dest"))
+              FileUtils.ln_s("old_target", File.join(backup_dir, "folder_dest", "file1"))
+
+              # Create a symlink in the source to back up
+              symlink_src = File.join(mapping1.dest, "link1")
+              FileUtils.ln_s("some_target", symlink_src)
+
+              subject
+
+              expect(Dir.exist?(backup_dir)).to eq(true)
+              backed_up_link = File.join(backup_dir, "folder_dest", "link1")
+              expect(File.symlink?(backed_up_link)).to eq(true)
+              expect(File.readlink(backed_up_link)).to eq("some_target")
+            end
+          end
+
           context "when there are more than 10 backups" do
             before do
               1.upto(12) do |day|


### PR DESCRIPTION
## Summary

- Fix `Errno::EEXIST` crash when `cp_r_regular_files` encounters pre-existing symlinks in the backup directory
- Add `FileUtils.rm_f` before `FileUtils.ln_s` to handle leftover symlinks from partial backup runs
- Bump version to 0.4.2

Closes #35

## Test plan

- [x] Added spec for pre-existing symlinks in backup directory
- [x] All existing specs pass (`bundle exec rspec spec/dotsync/actions/pull_action_spec.rb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)