### PR TITLE
Skip apply phase when no differences detected (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.4.5] - 2026-04-07
+
+### Fixed
+
+- Skip transfer, orphan cleanup, and hooks when no differences detected (#42)
+  - `pull` and `push` actions now early-exit the apply phase when no differences exist
+  - Eliminates expensive `Find.find` directory scans from `cleanup_orphans` on every run
+  - `force_hooks` option still executes hooks even without differences
+
 ## [0.4.4] - 2026-04-07
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dotsync (0.4.4)
+    dotsync (0.4.5)
       fileutils (~> 1.7.3)
       find (~> 0.2.0)
       listen (~> 3.9.0)

--- a/lib/dotsync/actions/pull_action.rb
+++ b/lib/dotsync/actions/pull_action.rb
@@ -33,9 +33,14 @@ module Dotsync
         end
       end
 
-      transfer_mappings
-      cleanup_orphans
-      execute_hooks(force: options[:force_hooks])
+      if has_differences?
+        transfer_mappings
+        cleanup_orphans
+        execute_hooks(force: options[:force_hooks])
+      elsif options[:force_hooks]
+        execute_hooks(force: true)
+      end
+
       action("Mappings pulled", icon: :done)
     end
 

--- a/lib/dotsync/actions/push_action.rb
+++ b/lib/dotsync/actions/push_action.rb
@@ -23,8 +23,13 @@ module Dotsync
         return unless confirm_action
       end
 
-      transfer_mappings
-      execute_hooks(force: options[:force_hooks])
+      if has_differences?
+        transfer_mappings
+        execute_hooks(force: options[:force_hooks])
+      elsif options[:force_hooks]
+        execute_hooks(force: true)
+      end
+
       action("Mappings pushed", icon: :done)
     end
   end

--- a/lib/dotsync/version.rb
+++ b/lib/dotsync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dotsync
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end

--- a/spec/dotsync/actions/pull_action_spec.rb
+++ b/spec/dotsync/actions/pull_action_spec.rb
@@ -116,6 +116,26 @@ RSpec.describe Dotsync::PullAction do
         expect(file_transfer2).to have_received(:transfer)
       end
 
+      context "without differences" do
+        before do
+          File.write(File.join(mapping1.dest, "file1"), "src content")
+          File.write(mapping2.dest, "#{mapping2.src} content")
+        end
+
+        it "skips transfer, orphan cleanup, and hooks" do
+          subject
+
+          expect(file_transfer1).not_to have_received(:transfer)
+          expect(file_transfer2).not_to have_received(:transfer)
+        end
+
+        it "still shows mappings pulled message" do
+          expect(logger).to receive(:action).with("Mappings pulled", icon: :done)
+
+          subject
+        end
+      end
+
       context "with user confirmation" do
         context "when user accepts" do
           before do
@@ -240,6 +260,30 @@ RSpec.describe Dotsync::PullAction do
 
               action.execute(force_hooks: true)
             end
+          end
+        end
+      end
+
+      context "with hooks and no differences" do
+        let(:mapping_with_hooks) do
+          Dotsync::Mapping.new(
+            "src" => file2_src,
+            "dest" => file2_dest,
+            "hooks" => ["echo hook_ran"]
+          )
+        end
+        let(:mappings) { [mapping1, mapping_with_hooks] }
+
+        before do
+          File.write(File.join(mapping1.dest, "file1"), "src content")
+          File.write(mapping_with_hooks.dest, "#{mapping_with_hooks.src} content")
+        end
+
+        context "with force_hooks option" do
+          it "executes hooks even without differences" do
+            expect_any_instance_of(Dotsync::HookRunner).to receive(:execute).and_return([])
+
+            action.execute(apply: true, yes: true, force_hooks: true)
           end
         end
       end

--- a/spec/dotsync/actions/push_action_spec.rb
+++ b/spec/dotsync/actions/push_action_spec.rb
@@ -114,6 +114,26 @@ RSpec.describe Dotsync::PushAction do
         expect(file_transfer2).to have_received(:transfer)
       end
 
+      context "without differences" do
+        before do
+          File.write(mapping1.dest, "src1 content")
+          File.write(mapping2.dest, "#{mapping2.src} content")
+        end
+
+        it "skips transfer and hooks" do
+          subject
+
+          expect(file_transfer1).not_to have_received(:transfer)
+          expect(file_transfer2).not_to have_received(:transfer)
+        end
+
+        it "still shows mappings pushed message" do
+          expect(logger).to receive(:action).with("Mappings pushed", icon: :done)
+
+          subject
+        end
+      end
+
       context "with user confirmation" do
         context "when user accepts" do
           before do
@@ -242,6 +262,33 @@ RSpec.describe Dotsync::PushAction do
 
               action.execute(force_hooks: true)
             end
+          end
+        end
+      end
+
+      context "with hooks and no differences" do
+        let(:mapping_with_hooks) do
+          Dotsync::Mapping.new(
+            "src" => File.join(root, "src2"),
+            "dest" => File.join(root, "dest2"),
+            "force" => false,
+            "ignore" => [],
+            "hooks" => ["echo hook_ran"]
+          )
+        end
+        let(:mappings) { [mapping1, mapping_with_hooks] }
+
+        before do
+          File.write(mapping1.dest, "src1 content")
+          File.write(mapping_with_hooks.src, "#{mapping_with_hooks.src} content")
+          File.write(mapping_with_hooks.dest, "#{mapping_with_hooks.src} content")
+        end
+
+        context "with force_hooks option" do
+          it "executes hooks even without differences" do
+            expect_any_instance_of(Dotsync::HookRunner).to receive(:execute).and_return([])
+
+            action.execute(apply: true, yes: true, force_hooks: true)
           end
         end
       end


### PR DESCRIPTION
## Summary

When `dotsync pull` or `push` detects no differences, the apply phase (`transfer_mappings`, `cleanup_orphans`, `execute_hooks`) still ran unnecessarily. The main bottleneck was `cleanup_orphans` calling `Find.find` on every destination directory with inclusion filters.

Closes #41

## Changes

**Code**
- `pull_action.rb`: Guard transfer/cleanup/hooks behind `has_differences?`; preserve `force_hooks` via `elsif` branch
- `push_action.rb`: Same pattern for transfer/hooks

**Tests (6 new examples)**
- Pull: no-differences + apply skips transfer/cleanup/hooks; shows "Mappings pulled"; `force_hooks` still works
- Push: no-differences + apply skips transfer/hooks; shows "Mappings pushed"; `force_hooks` still works

## Test plan

- [x] `bundle exec rspec` — 547 examples, 0 failures
- [x] `bundle exec rubocop` — passed (pre-commit hook)
- [x] Coverage: 96.54% line, 83.3% branch (above 95%/80% minimums)